### PR TITLE
Add Hanno Becker to TSC members

### DIFF
--- a/members/index.md
+++ b/members/index.md
@@ -3,6 +3,7 @@
 The current TSC members are:
 
 * [Manuel Barbosa](https://github.com/mbbarbosa)
+* [Hanno Becker](https://github.com/hanno-becker)
 * [Nigel Jones](https://github.com/planetf1)
 * [Matthias J. Kannwischer](https://github.com/mkannwischer)
 * [Franziskus Kiefer](https://github.com/franziskuskiefer)


### PR DESCRIPTION
I'd like to propose Hanno Becker from AWS as an additional TSC member. He is going to join me in maintaining https://github.com/pq-code-package/mlkem-c-aarch64.