### PR TITLE
Add rod-chapman to pqcp-contributors

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -80,6 +80,7 @@ teams:
       - tfaoliveira
       - ashman-p
       - ydoroz
+      - rod-chapman
   - name: pqcp-embedded-admin
     maintainers:
       - mkannwischer


### PR DESCRIPTION
rod-chapman has been making various contributions to mlkem-c-aarch64 and it would be great if he could also review other pull requests. My understanding is that adding him to the pqcp-contributors would allow that.
