### PR TITLE
Re-work mlkem-c-aarch64 permissions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-config.yaml @ryjones @pq-code-package/pqcp-tsc-admin
+config.yaml @pq-code-package/pqcp-tsc-admin

--- a/config.yaml
+++ b/config.yaml
@@ -15,10 +15,9 @@ repositories:
   - name: mlkem-c-aarch64
     teams:
       bots: admin
-      pqcp-embedded: read
-      pqcp-embedded-admin: admin
-      pqcp-embedded-maintainers: maintain
-      pqcp-embedded-maintainers-aarch64: maintain
+      pqcp-c-aarch64-admin: admin
+      pqcp-c-aarch64-contributors: write
+      pqcp-c-aarch64-maintainers: maintain
       pqcp-tsc: read
   - name: mlkem-c-embedded
     teams:
@@ -89,12 +88,6 @@ teams:
     maintainers:
       - mkannwischer
       - planetf1
-  - name: pqcp-embedded-maintainers-aarch64
-    maintainers:
-      - mkannwischer
-    members:
-      - cothan
-      - hanno-becker
   - name: pqcp-embedded-maintainers
     maintainers:
       - mkannwischer
@@ -111,6 +104,24 @@ teams:
       - rpls
       - potsrevennil
       - jschanck
+  - name: pqcp-c-aarch64-admin
+    maintainers:
+      - mkannwischer
+      - planetf1
+  - name: pqcp-c-aarch64-maintainers
+    maintainers:
+      - mkannwischer
+    members:
+      - cothan
+      - hanno-becker
+  - name: pqcp-c-aarch64-contributors
+    maintainers:
+      - mkannwischer
+      - cothan
+      - hanno-becker
+    members:
+      - potsrevennil
+      - rod-chapman
   - name: pqcp-generic-admin
     maintainers:
       - jschanck


### PR DESCRIPTION
For some of the CI to work in https://github.com/pq-code-package/mlkem-c-aarch64, the PRs need to come from a local branch. @rod-chapman should be granted the rights to do so - my understand is that creating branches requires at least `write` permissions. 

I used the opportunity to rework the permissions for the mlkem-c-aarch64 repo, as they have been mixed with the mlkem-embedded project as some team members overlap.

Now there are 3 roles: 
 - `pqcp-c-aarch64-maintainers` (`maintain` permission) containing the maintainers as before (@hanno-becker, @cothan, @mkannwischer) 
 - `pqcp-c-aarch64-contributors` (`write` permission) containins @rod-chapman, @potsrevennil
 - `pqcp-c-aarch64-admin` as a copy of the previous `pqcp-embedded-admin`


@hanno-becker, @cothan, could you please have a look if I got this right? 