### PR TITLE
Move cothan from maintainer to contributor for mlkem-c-aarch64 

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -112,14 +112,13 @@ teams:
     maintainers:
       - mkannwischer
     members:
-      - cothan
       - hanno-becker
   - name: pqcp-c-aarch64-contributors
     maintainers:
       - mkannwischer
-      - cothan
       - hanno-becker
     members:
+      - cothan
       - potsrevennil
       - rod-chapman
   - name: pqcp-generic-admin


### PR DESCRIPTION
@cothan will move to a contributor role for mlkem-c-aarch64 leaving @hanno-becker and me as the maintainers. 

@cothan, thank you for your help with getting this project started! Please approve this PR if you agree with this change.
@hanno-becker, please approve. 