### PR TITLE
Remove Douglas Stebila from TSC

### DIFF
--- a/members/index.md
+++ b/members/index.md
@@ -11,7 +11,6 @@ The current TSC voting members are:
 * [Tiago Oliveira](https://github.com/tfaoliveira)
 * [John Schanck](https://github.com/jschanck)
 * [Pravek Sharma](https://github.com/praveksharma)
-* [Douglas Stebila](https://github.com/dstebila)
 
 Anyone is welcome to contribute to the work of the TSC through meetings, issues & other activities.
 


### PR DESCRIPTION
With @praveksharma on the PQCP TSC, we have a great liaison between OQS and PQCP, so I think it's time for me to resign from the PQCP TSC and avoid messing up your quorum threshold. I'm really impressed with the great work that's developed, especially how well mlkem-native has come together.  (In fact I used mlkem-native in a research project yesterday!)  Keep up the good work!  And do ping me if there's anything I can do to help in the future.