### PR TITLE
Add TSC voting members to pqcp-tsc-maintainers group (maintain on tsc repo)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -241,6 +241,15 @@ teams:
     maintainers:
       - dstebila
       - planetf1
+    members:
+      - franziskuskiefer
+      - hanno-becker
+      - jschanck
+      - mbbarbosa
+      - mkannwischer
+      - tfaoliveira
+      - praveksharma
+      - jakemas
   - name: pqcp-tsc-admin
     maintainers:
       - dstebila


### PR DESCRIPTION
Signed-off-by: Nigel Jones <jonesn@uk.ibm.com>

This PR grants maintain access to the current TSC voting members which allows them to assign/manage reviews and merge PRs
