### PR TITLE
2026-01-08 TSC meeting

### DIFF
--- a/meetings/2026-01-08/minutes.md
+++ b/meetings/2026-01-08/minutes.md
@@ -1,0 +1,54 @@
+# 2025-12-04: TSC Minutes
+
+## Agenda
+
+* Welcome
+* Approval of minutes from previous meeting: [2025-12-04](https://github.com/pq-code-package/tsc/pull/192)
+* Updates from related communities (PQCA, OQS)
+* Review status of sub projects
+  * [mlkem-native](https://github.com/pq-code-package/mlkem-native)
+  * [mldsa-native](https://github.com/pq-code-package/mldsa-native)
+  * [mlkem-libjade](https://github.com/pq-code-package/mlkem-libjade)
+  * [rust-libcrux](https://github.com/pq-code-package/rust-libcrux)
+  * [slhdsa-c](https://github.com/pq-code-package/slhdsa-c)
+* Discussion items
+  * TSC membership: Pravek Sharma
+    - Pravek left OQS team/UWaterloo
+    - Last PQCP TSC meeting attendance: 2025-07-03
+    - I asked him to step down from the PQCP TSC on 2025-11-07 - no response
+    - Vote to remove him from the TSC
+  * [PQCP Growth Plan](https://github.com/pq-code-package/tsc/issues/188) - Status update
+    - [X] mlkem-native
+    - [X] mldsa-native
+    - [X] mlkem-libjade
+    - [ ] rust-libcrux
+    - [ ] slhdsa-c
+  * [Project Documentation Standards](https://github.com/pq-code-package/tsc/issues/151) - Implementation status
+    - [X] [mlkem-native](https://github.com/pq-code-package/mlkem-native/issues/1289)
+    - [X] [mldsa-native](https://github.com/pq-code-package/mldsa-native/issues/634)
+    - [X] [mlkem-libjade](https://github.com/pq-code-package/mlkem-libjade/issues/4)
+    - [ ] [rust-libcrux](https://github.com/pq-code-package/rust-libcrux/issues/6)
+    - [ ] [slhdsa-c](https://github.com/pq-code-package/slhdsa-c/issues/38)
+  * Review of remaining open issues:
+    - [Determine any cross-implementation API requirements](https://github.com/pq-code-package/tsc/issues/4)
+    - [Adopt a definition of assurance levels](https://github.com/pq-code-package/tsc/issues/3)
+* Any other business
+* Next meeting: 2026-01-08 13:00 UTC 
+
+## Attendees
+TSC members:
+* [ ] Manuel Barbosa
+* [ ] Hanno Becker
+* [ ] Matthias J. Kannwischer
+* [ ] Franziskus Kiefer
+* [ ] Jake Massimo
+* [ ] Tiago Oliveira
+* [ ] Pravek Sharma
+* [ ] Markku-Juhani Saarinen
+
+## Minutes
+
+Meeting has been cancelled due to lack of people that plan to attend, see https://github.com/pq-code-package/tsc/pull/195.
+
+
+**Next meeting: 2026-02-05 13:00 UTC**

--- a/meetings/index.md
+++ b/meetings/index.md
@@ -1,4 +1,5 @@
 # Minutes and agenda
+* 2026-01-08 : [agenda/minutes](2026-01-08/minutes.md)
 * 2025-12-04 : [agenda/minutes](2025-12-04/minutes.md)
 * 2025-11-06 : [agenda/minutes](2025-11-06/minutes.md)
 * 2025-10-02 : [agenda/minutes](2025-10-02/minutes.md)


### PR DESCRIPTION
This is the draft agenda for this weeks TSC meeting scheduled for **2026-01-08 13:00 UTC**

@pq-code-package/pqcp-tsc, please indicate with a 👍 if you are planning to attend this meeting.
If no quorum (4 attendees with voting rights) is expected by **2026-01-08 10:00 UTC**, the meeting will be cancelled and votes will be held on Github instead. 