### PR TITLE
Add Aaron Kaiser (@rixxc) as mlkem/mldsa-native contributor

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -113,6 +113,7 @@ teams:
       - manastasova
       - jricardini
       - flynd
+      - Rixxc
   - name: pqcp-mldsa-native-admin
     maintainers:
       - mkannwischer
@@ -137,6 +138,7 @@ teams:
       - f15hr
       - jricardini
       - flynd
+      - Rixxc
   - name: pqcp-slhdsa-c-admin
     maintainers:
       - mkannwischer


### PR DESCRIPTION
Aaron is working with us on providing Rust bindings to the mlkem-native and mldsa-native libraries.